### PR TITLE
Support IAM roles for service accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM nginx:1.18.0-alpine
 
-RUN apk -v --update add \
-        python \
-        py-pip \
-        && \
-    pip install --upgrade pip awscli==1.11.92 && \
-    apk -v --purge del py-pip && \
-    rm /var/cache/apk/*
+RUN apk add --no-cache \
+    --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/community \
+    aws-cli
 
 ADD configs/nginx/nginx.conf /etc/nginx/nginx.conf
 ADD configs/nginx/ssl /etc/nginx/ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.12.0-alpine
+FROM nginx:1.18.0-alpine
 
 RUN apk -v --update add \
         python \

--- a/README.md
+++ b/README.md
@@ -8,45 +8,39 @@ The container will renew the aws token every 6 hours.
 
 Variables:
 ```
-AWS_KEY
-AWS_SECRET
 REGION
 RENEW_TOKEN - default 6h
 REGISTRY_ID - optional, used for cross account access
 ```
 
-### Health check 
+### Health check
 
 To check the health of the container/registry use ```FQDN/ping``` which will give you the heath of the registry with the correct status code. 
 
-### AWS instance with IAM role
+### AWS ECR region
 
 For AWS instances if the region is not declared it will be auto discovered from IAM as long as the instance supports that. [pull request](https://github.com/catalinpan/aws-ecr-proxy/pull/1/commits/899ef1a80a7fa141f66e500a76f6ed86f8d19f4e), [commit](https://github.com/catalinpan/aws-ecr-proxy/commit/d8a709bf043cfd14b88defae738833e93c946f4b).
 
-The AWS key and secret can be also configured using a IAM role (without mounting them secrets or specifying them as variables). A sample IAM role config can be found in the examples folder. More details on the [AWS official documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).
+### IAM credentials
 
-The configs will be checked in the following order:
+For information about various ways to provide IAM credentials see the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence)
 
-- secrets - file mounted
-- variables declared at run time
-- IAM role
-
-If none are found the container will not start. Check the logs with ```docker logs CONTAINER_ID```
+If ECR access is not configured the container will not start. Check the logs with ```docker logs CONTAINER_ID```
 
 ## Docker run:
 ##### Without ssl
 This will require either to add insecure registry URL or a load balancer with valid ssl certificates.
 Check https://docs.docker.com/registry/insecure/ for more details.
 ```
-docker run -e AWS_SECRET='YOUR_AWS_SECRET' \
--e AWS_KEY='YOUR_AWS_KEY' \
+docker run -e AWS_SECRET_ACCESS_KEY='YOUR_AWS_SECRET' \
+-e AWS_ACCESS_KEY_ID='YOUR_AWS_KEY' \
 -e REGION='YOUR_AWS_REGION' \
 -d catalinpan/aws-ecr-proxy
 ```
 ##### With your own certificate
 ```
-docker run -e AWS_SECRET='YOUR_AWS_SECRET' \
--e AWS_KEY='YOUR_AWS_KEY' \
+docker run -e AWS_SECRET_ACCESS_KEY='YOUR_AWS_SECRET' \
+-e AWS_ACCESS_KEY_ID='YOUR_AWS_KEY' \
 -e REGION='YOUR_AWS_REGION' \
 -v `pwd`/YOUR_CERTIFICATE.key:/etc/nginx/ssl/default.key:ro \
 -v `pwd`/YOUR_CERTIFICATE.crt:/etc/nginx/ssl/default.crt:ro \

--- a/configs/entrypoint.sh
+++ b/configs/entrypoint.sh
@@ -48,26 +48,13 @@ else
   exit 1
 fi
 
-# test if key and secret are mounted as secret
-if test_config aws_access_key_id
+
+if aws ecr get-authorization-token | grep expiresAt
 then
-    echo "aws key and secret found in ~/.aws mounted as secrets"
-# if both key and secret are declared
-elif [[ "$AWS_KEY" != "" && "$AWS_SECRET" != "" ]]
-then
-    echo "aws_access_key_id = $AWS_KEY
-aws_secret_access_key = $AWS_SECRET" >> ${AWS_FOLDER}/config
-    fix_perm
-# if the key and secret are not mounted as secrets
+    echo "IAM role configured to allow ECR access."
 else
-    echo "key and secret not available in ~/.aws/"
-    if aws ecr get-authorization-token | grep expiresAt
-    then
-        echo "iam role configured to allow ecr access"
-    else
-        echo "key and secret not mounted as secret, declared as variables or available from iam role"
-        exit 1
-    fi
+    echo "Error: ECR access not configured."
+    exit 1
 fi
 
 # update the auth token

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -10,11 +10,11 @@ http {
     listen 80 default_server;
     server_name _;
 
-    location / {
+    location /v2/ {
       set $upstream           REGISTRY_URL;
 
       proxy_pass              $upstream;
-      proxy_redirect          $upstream https://$host;
+      proxy_redirect          $upstream http://$host;
 
       proxy_set_header        X-Real-IP            $remote_addr;
       proxy_set_header        X-Forwarded-For      $remote_addr;
@@ -32,13 +32,12 @@ http {
   }
 
   server {
-    listen 443 default_server;
+    listen 443 ssl;
     server_name _;
-    ssl on;
     ssl_certificate           /etc/nginx/ssl/default.crt;
     ssl_certificate_key       /etc/nginx/ssl/default.key;
 
-    location / {
+    location /v2/ {
       set $upstream           REGISTRY_URL;
 
       proxy_pass              $upstream;


### PR DESCRIPTION
- Update `aws` cli to a version which supports `AssumeRoleWithWebIdentity`, needed for IAM roles for service accounts - [docs](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html).
- Update to a supported version of Alpine and Nginx.
- Update to use Docker Registry HTTP API V2 - [docs](https://docs.docker.com/registry/recipes/nginx/).